### PR TITLE
Pequenas alterações

### DIFF
--- a/projects/project_2/stage1/client_U1.c
+++ b/projects/project_2/stage1/client_U1.c
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
         printf("Usage: %s <-t nsec> <fifoname>\n", argv[0]);
         exit(1);
     }
-    client_args_t args = parse_client_args(argc, argv);
+    client_args_t args = parse_client_args(argv);
 
     do {
         server = open(args.server_fifo, O_WRONLY);
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
         request.pl = -1;
 
         pthread_create(&tid, NULL, thr_function, &request);
-        usleep(1000000);    /* microsecs */
+        sleep(1000000);    /* microsecs */
         time += 1000000;
     }
 

--- a/projects/project_2/stage1/server_Q1.c
+++ b/projects/project_2/stage1/server_Q1.c
@@ -52,12 +52,12 @@ void* thr_function(void* arg) {
 
 
 int main(int argc, char** argv) {
-    if (argc < 4) {
+    if (argc != 4) {
         printf("--- SERVER 1 ---\n");
         printf("Usage: %s <-t nsec> <fifoname>\n", argv[0]);
         exit(1);
     }
-    server_args_t args = parse_server_args(argc, argv);
+    server_args_t args = parse_server_args(argv);
 
     if (mkfifo(args.fifoname, 0660) != 0) {
         printf("Error on mkfifo\n");

--- a/projects/project_2/stage1/utils.c
+++ b/projects/project_2/stage1/utils.c
@@ -13,34 +13,23 @@ void log_message(int i, pid_t pid, pid_t tid, int dur, int pl, char *oper) {
     write(STDOUT_FILENO, message, strlen(message));
 }
 
-client_args_t parse_client_args(int argc, char **argv) {
+client_args_t parse_client_args(char **argv) {
     client_args_t result;
 
-    for (int i = 1; i < argc; i++) {
-        if (strcmp("-t", argv[i]) == 0)
-            result.seconds = atoi(argv[++i]);
-        else
-            result.server_fifo = argv[i];
-    }
+    result.seconds = atoi(argv[2]);
+    result.server_fifo = argv[3];
 
     return result;
 }
 
-server_args_t parse_server_args(int argc, char **argv) {
+server_args_t parse_server_args(char **argv) {
+    
     server_args_t result;
-
-    result.nthreads = 0; result.nplaces = 0;
-
-    for (int i = 1; i < argc; i++) {
-        if (strcmp("-t", argv[i]) == 0)
-            result.seconds = atoi(argv[++i]);
-        else if (strcmp("-l", argv[i]) == 0)
-            result.nplaces = atoi(argv[++i]);
-        else if (strcmp("-n", argv[i]) == 0)
-            result.nthreads = atoi(argv[++i]);
-        else
-            result.fifoname = argv[i];
-    }
+ 
+    result.seconds = atoi(argv[2]);
+    result.nplaces = 0;
+    result.nthreads = 0;
+    result.fifoname = argv[3];
 
     return result;
 }

--- a/projects/project_2/stage1/utils.h
+++ b/projects/project_2/stage1/utils.h
@@ -13,7 +13,6 @@
 #include <unistd.h>
 #include <string.h>
 
-/* i, pid, tid, dur, pl */
 typedef struct {
     int id;
     pid_t pid;
@@ -34,14 +33,13 @@ typedef struct {
     char* fifoname;
 } server_args_t;
 
-
-
 /* inst ; i ; pid ; tid ; dur ; pl ; oper */
 void log_message(int i, pid_t pid, pid_t tid, int dur, int pl, char *oper);
-/* -t <time> <fifoname> */
-client_args_t parse_client_args(int argc, char** argv);
 
-/* -t nsecs [-l nplaces] [-n nthreads] fifoname */
-server_args_t parse_server_args(int argc, char** argv);
+/* -t <time> <fifoname> */
+client_args_t parse_client_args(char** argv);
+
+/* -t <nsecs> <fifoname> */
+server_args_t parse_server_args(char** argv);
 
 #endif //PROJECT_2_UTILS_H


### PR DESCRIPTION
Simplifiquei as funções parse_client_args(int argc, char **argv) e parse_server_args(int argc, char **argv) de forma a eliminar o ciclo for e as comparações que tinha. Isto porque, no caso do U1, que será igual ao U2, sabemos que os argumentos são recebidos sempre na forma **./U1 -t nsec fifoname**, ou seja, o número de segundos será sempre igual a **argv[2]** e o nome do fifo será sempre **argv[3]**. Para o caso do Q1, por enquanto podemos seguir a mesma abordagem do U1, uma vez que para a primeira entrega não devemos considerar os argumentos **-l nplaces** e **-n
nthreads**. No entanto, para a segunda entrega, teremos então de ter o ciclo for porque estes argumentos podem (ou não) estar presentes. As funções acima mencionadas deixam de receber como argumento o argc. No main do Q1, em vez de verificar **argc<4**, verifica **argc!=4**