### PR TITLE
Execution Time solved

### DIFF
--- a/projects/project_2/stage1/client_U1.c
+++ b/projects/project_2/stage1/client_U1.c
@@ -66,7 +66,9 @@ int main(int argc, char** argv) {
     while (time < timeout) {
         pthread_t tid;
         message_t request;
-        request.dur = 10;
+        /* a duração do pedido do cliente para utilizar 
+        a casa de banho será um valor entre 1s e 5s */
+        request.dur = (rand() % (5000000 - 1000000 + 1)) + 1000000; 
         request.id = request_id++;
         request.pl = -1;
 

--- a/projects/project_2/stage1/server_Q1.c
+++ b/projects/project_2/stage1/server_Q1.c
@@ -37,14 +37,8 @@ void* thr_function(void* arg) {
 
     write(client, &reply, sizeof(message_t));
 
-    // TODO - Verificar o tempo de utilização do WC:
-
-    /* -> utilizar usleep ?
-     *      usleep conta o tempo em microsecs
-     *
-     * -> O servidor é responsável por emitir a mensagem de TIMEUP não o cliente:
-     *      será que o tempo de espera fica no lado do servidor ou no lado do cliente?
-     */
+    usleep(request->dur);
+    log_message(request->id, getpid(), tid, request->dur, 1, "TIMUP");
 
     close(client);
     return NULL;


### PR DESCRIPTION
Na minha opinião, o tempo de espera fica no lado do servidor. Apesar de ser o cliente a utilizar, é o servidor que está a ser "alvo" desse tempo e que controla quando fica disponível, assim que terminar o tempo.

Duração do pedido - a duração de um pedido (request.dur) estava como um valor fixo, 10. Alterei de forma a que, tal como é pedido no enunciado, e passo a citar, "cada thread gera aleatoriamente parâmetros do pedido pelo qual é responsável (especificamente, a duração do acesso)", ou seja, gera agora uma duração no intervalo 1s a 5s (pus apenas este intervalo porque achei ser o mais adequado. Se acharem que outro intervalo de valores fica melhor, alterem sem problema nenhum).

Ao ter isto dentro da thread function, significa que se o tempo de execução do programa for superior a 5 segundos, é sempre garantido que pelo menos um cliente é "servido". Caso contrário, não. Ou seja,  o tempo de execução do programa passado como argumento prevalece em relação ao usleep(). (Ainda assim, se puderem verificar isto...)