### PR TITLE
Limitação do número de pthreads simultâneas

### DIFF
--- a/projects/project_2/stage2/Makefile
+++ b/projects/project_2/stage2/Makefile
@@ -21,23 +21,23 @@ Q2: $(OBJ)
 test: all
 	@echo "Starting Tests ..."
 	@touch result.log
-	@./test -q 2 -u 3 -f fifo.server | tee -a result.log
+	@./test -q 2 -u 3 -f fifo.server -n 5 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 5 -u 5 -f fifo.server | tee -a result.log
+	@./test -q 5 -u 5 -f fifo.server -n 1 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 2 -u 5 -f fifo.server | tee -a result.log
+	@./test -q 2 -u 5 -f fifo.server -n 2 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 10 -u 10 -f fifo.server | tee -a result.log
+	@./test -q 10 -u 10 -f fifo.server -n 20 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 5 -u 10 -f fifo.server | tee -a result.log
+	@./test -q 5 -u 10 -f fifo.server -n 50 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 10 -u 5 -f fifo.server | tee -a result.log
+	@./test -q 10 -u 5 -f fifo.server -n 0 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 15 -u 10 -f fifo.server | tee -a result.log
+	@./test -q 15 -u 10 -f fifo.server -n 1000 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 30 -u 35 -f fifo.server | tee -a result.log
+	@./test -q 30 -u 35 -f fifo.server -n 2 | tee -a result.log
 	@echo "----------------------------"
-	@./test -q 70 -u 80 -f fifo.server | tee -a result.log
+	@./test -q 70 -u 80 -f fifo.server -n 10 | tee -a result.log
 	@echo "----------------------------"
 
 

--- a/projects/project_2/stage2/Q2.c
+++ b/projects/project_2/stage2/Q2.c
@@ -60,9 +60,9 @@ void* thr_function(void* arg) {
 
 
 int main(int argc, char** argv) {
-    if (argc != 4) {
-        printf("--- SERVER 1 ---\n");
-        printf("Usage: %s <-t nsec> <fifoname>\n", argv[0]);
+    if (argc < 4 || argc > 8) {
+        printf("--- SERVER 2 ---\n");
+        printf("Usage: %s <-t nsec> <-l nplaces> <-t nthreads> <fifoname>\n", argv[0]);
         exit(1);
     }
     server_args_t args = parse_server_args(argc, argv);
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
      while (delta() < timeout) {
         message_t request;
         while (read(fd, &request, sizeof(message_t)) <= 0 && delta() < timeout) {
-            usleep(10000);
+            usleep(1000);
         }
 
         /* Esta linha verifica se o tempo já passou devido ao usleep

--- a/projects/project_2/stage2/U2.c
+++ b/projects/project_2/stage2/U2.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <pthread.h>
-#include <sys/syscall.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -53,7 +52,7 @@ void* thr_function(void* arg) {
 
 int main(int argc, char** argv) {
     if (argc != 4) {
-        printf("--- CLIENT 1 ---\n");
+        printf("--- CLIENT 2 ---\n");
         printf("Usage: %s <-t nsec> <fifoname>\n", argv[0]);
         exit(1);
     }

--- a/projects/project_2/stage2/U2.c
+++ b/projects/project_2/stage2/U2.c
@@ -76,9 +76,9 @@ int main(int argc, char** argv) {
         message_t request;
         /*
          * a duração do pedido do cliente para utilizar
-         * a casa de banho será um valor entre 20 e 40 milissegundos
+         * a casa de banho será um valor entre 20 e 200 milissegundos
          */
-        request.dur = (rand() % (40 - 20 + 1)) + 20;
+        request.dur = (rand() % (200 - 20 + 1)) + 20;
         request.id = request_id++;
         request.pl = -1;
 

--- a/projects/project_2/stage2/U2.c
+++ b/projects/project_2/stage2/U2.c
@@ -17,8 +17,11 @@ void* thr_function(void* arg) {
     pthread_t tid;
     pthread_detach(tid = pthread_self());
 
-    ((message_t*) arg)->tid = tid;
-    ((message_t*) arg)->pid = getpid();
+    message_t request;
+    memcpy(&request, ((message_t*) arg), sizeof(message_t));
+
+    request.tid = tid;
+    request.pid = getpid();
 
     char client_fifo[64];
     sprintf(client_fifo, "/tmp/%d.%ld", getpid(), tid);
@@ -29,29 +32,16 @@ void* thr_function(void* arg) {
     }
     int client = open(client_fifo, O_RDONLY | O_NONBLOCK);
 
-    write(server, (message_t *) arg, sizeof(message_t));
-    log_message(((message_t*) arg)->id, ((message_t*) arg)->pid, ((message_t*) arg)->tid, ((message_t*) arg)->dur, ((message_t*) arg)->pl, "IWANT");
+    write(server, &request, sizeof(message_t));
+    log_message(request.id, request.pid, request.tid, request.dur, request.pl, "IWANT");
 
     signal(SIGPIPE, SIG_IGN);
     if (access(server_path, F_OK) != -1) {
         message_t reply;
-        /*
-         * A variável counter representa o numero de tentativas de leitura do servidor
-         * antes de considerar que o servidor já fechou. Depois de fechar será emitido
-         * um sinal de SIGPIPE que vai ser ignorado, voltado para o else, e dessa forma
-         * dado um output de "FAILD".
-         */
-        int counter = 0;
-        while (read(client, &reply, sizeof(message_t)) <= 0 && counter < 5) {
-            usleep(10000);
-            counter++;
-        }
-        if (counter < 5)
-            log_message(reply.id, getpid(), tid, reply.dur, reply.pl, (reply.pl != -1) ? "IAMIN" : "CLOSD");
-        else
-            log_message(((message_t*) arg)->id, ((message_t*) arg)->pid, ((message_t*) arg)->tid, ((message_t*) arg)->dur, ((message_t*) arg)->pl, "FAILD");
+        while (read(client, &reply, sizeof(message_t)) <= 0) { usleep(1000); }
+        log_message(reply.id, getpid(), tid, reply.dur, reply.pl, (reply.pl != -1) ? "IAMIN" : "CLOSD");
     } else {
-        log_message(((message_t*) arg)->id, ((message_t*) arg)->pid, ((message_t*) arg)->tid, ((message_t*) arg)->dur, ((message_t*) arg)->pl, "FAILD");
+        log_message(request.id, request.pid, request.tid, request.dur, request.pl, "FAILD");
     }
 
     close(client);
@@ -87,15 +77,15 @@ int main(int argc, char** argv) {
         message_t request;
         /*
          * a duração do pedido do cliente para utilizar
-         * a casa de banho será um valor entre 20 e 100 milissegundos
+         * a casa de banho será um valor entre 20 e 40 milissegundos
          */
-        request.dur = (rand() % (100 - 20 + 1)) + 20;
+        request.dur = (rand() % (40 - 20 + 1)) + 20;
         request.id = request_id++;
         request.pl = -1;
 
         pthread_create(&tid, NULL, thr_function, &request);
 
-        usleep(50000); /* pedidos com intervalo de 50ms */
+        usleep(20000); /* pedidos com intervalo de 20ms */
     }
 
     exit(0);

--- a/projects/project_2/stage2/test
+++ b/projects/project_2/stage2/test
@@ -91,7 +91,7 @@ fi
 
 cd ..
 # comment this line if you wish to keep the log files (debugging purposes)
-#rm -rf logs
+rm -rf logs
 
 if [[ $valid1 -eq 1 && $valid2 -eq 1 && $valir3 -eq 1 ]] ; then
   exit 0;

--- a/projects/project_2/stage2/test
+++ b/projects/project_2/stage2/test
@@ -2,7 +2,7 @@
 
 # Adapted from André Daniel Gomes's Test script
 
-# usage|help|info: ./test -q <server timeout> -u <client timeout> -f <server fifo>
+# usage|help|info: ./test -q <server timeout> -u <client timeout> -f <server fifo> -n <nthreads> -l <nplaces>
 
 RED='\033[1;31m'
 GREEN='\033[1;32m'
@@ -12,12 +12,16 @@ NC='\033[0m' # No Color
 serverTime=10
 clientTime=15
 fifoname='fifo.server'
+nthreads=0
+nplaces=0
 
-while getopts ":q:u:f:" opt; do
+while getopts ":q:u:f:n:l:" opt; do
   case $opt in
     q) serverTime=$OPTARG;;
     u) clientTime=$OPTARG;;
     f) fifoname=$OPTARG;;
+    n) nthreads=$OPTARG;;
+    l) nplaces=$OPTARG;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       exit 1
@@ -32,13 +36,15 @@ done
 mkdir logs
 echo "Setting server timeout to "$serverTime"sec"
 echo "Setting client timeout to "$clientTime"sec"
+echo "Setting max threads to "$nthreads""
+echo "Setting max places to "$nplaces""
 echo "SERVER/CLIENT RUNNING ..."
 
-./Q2 -t $serverTime "$fifoname" > logs/q2.log 2> logs/q2.err &  # Un <-t nsecs> fifoname
+./Q2 -t $serverTime -n "$nthreads" -l "$nplaces" "$fifoname" > logs/q2.log 2> logs/q2.err &  # Un <-t nsecs> fifoname
 P1=$!
 ./U2 -t $clientTime "$fifoname" > logs/u2.log 2> logs/u2.err &   # Qn <-t nsecs> [-l nplaces] [-n nthreads] fifoname
 P2=$!
-wait $P1 $P2
+wait
 echo "END OF SERVER/CLIENT"
 
 cd logs || exit
@@ -66,21 +72,21 @@ if  [ $n2LATE -eq $nCLOSD ] ; then
   echo -e "${GREEN}[PASSED] ${NC}2LATE - too late requests: $n2LATE"
   valid1=1;
 else
-  echo -e "${RED}[FAILED] ${NC}2LATE"
+  echo -e "${RED}[FAILED] ${NC}2LATE - 2LATE=$n2LATE | CLOSD=$nCLOSD "
 fi
 
 if  [ $nIAMIN -eq $nENTER ] ; then
   echo -e "${GREEN}[PASSED] ${NC}ENTER - accepted requests: $nENTER"
   valid2=1;
 else
-  echo -e "${RED}[FAILED] ${NC}ENTER"
+  echo -e "${RED}[FAILED] ${NC}ENTER - IAMIN=$nIAMIN | ENTER=$nENTER"
 fi
 
 if  [ $nTIMUP -eq $nENTER ] ; then
   echo -e "${GREEN}[PASSED] ${NC}TIMEUP - fulfilled requests: $nTIMUP"
   valid3=1;
 else
-  echo -e "${RED}[FAILED] ${NC}TIMEUP"
+  echo -e "${RED}[FAILED] ${NC}TIMEUP - TIMUP=$nTIMUP | ENTER=$nENTER"
 fi
 
 cd ..

--- a/projects/project_2/stage2/utils.c
+++ b/projects/project_2/stage2/utils.c
@@ -11,6 +11,7 @@ void log_message(int i, pid_t pid, pthread_t tid, int dur, int pl, char *oper) {
 
     sprintf(message, "%ld ; %d ; %d ; %ld ; %d ; %d ; %s\n", t, i, pid, tid, dur, pl, oper);
     write(STDOUT_FILENO, message, strlen(message));
+    free(message);
 }
 
 client_args_t parse_client_args(char **argv) {


### PR DESCRIPTION
Implementei a funcionalidade de limitar o número de threads adicionais a correr simultaneamente. 
Agora é possivel usar a opção `-n` para limitar o número de threads.

Fiz algumas alterações tanto no lado do cliente como no lado do servidor em relação a possíveis erros que possam ocorrer em runtime. Essas alterações estão devidamente comentadas assim como outras alterações não mencionadas.

O script de testes tambem foi atualizado: agora é possivel usar a opção `-n` para limitar o número de threads, e `-l` para limitar o número de lugares ainda que esta última funcionalidade não tenha sido implementada neste momento. Além disso, o Makefile também foi atualizado para contemplar esta nova funcionalidade nos testes.

No fim deste PR vou criar um novo workflow para testar o código da segunda etapa sempre que ocorrer um push, tal como fiz para a primeira etapa.